### PR TITLE
HTTP, not HTTPS

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -72,7 +72,7 @@
 
 				<p>We hope to clear doubts in developers so that we can continue doing what we love: hacking a great experience for our users.</p>
 
-				<p>Butter will be able to leverage all of the traditional Open Source internet infrastructure: it will have its own webpage at <a href="https://butterproject.org">https://butterproject.org</a>, its own twitter account @butterproject, its own facebook at <br>
+				<p>Butter will be able to leverage all of the traditional Open Source internet infrastructure: it will have its own webpage at <a href="http://butterproject.org">https://butterproject.org</a>, its own twitter account @butterproject, its own facebook at <br>
 				    <a href="https://fb.me/ButterProjectOrg">https://fb.me/ButterProjectOrg</a> and its own G+ here <a href="https://plus.google.com/communities/111003619134556931561">https://plus.google.com/communities/111003619134556931561</a> . We are making sure butter is absolutely not using the popcorntime.io infrastructure to make a clear separation of concerns.</p>
 
 				<p>We're making Butter like any Open Source project: open governance by the contributors and easy to fork. Planing on making a Popcorn Time clone ? don't do it from scratch use some Butter to make it awesome !</p>


### PR DESCRIPTION
`https://butterproject.org` 404s. The correct domain is `http://butterproject.org`.